### PR TITLE
Fixing IPv4 dig (as we only set A records)

### DIFF
--- a/CloudFlareDNSUpdate.sh
+++ b/CloudFlareDNSUpdate.sh
@@ -4,7 +4,7 @@
 #clear
 
 #Get the public IP address of the server
-myIP=`dig +short myip.opendns.com @resolver1.opendns.com`
+myIP=`dig -4 +short myip.opendns.com @resolver1.opendns.com`
 
 #Store the cloudflare zone ID
 #Get this information from your cloudflare dashboard


### PR DESCRIPTION
In case the net iface has an IPv6 address (?) dig +short myip.opendns.com @resolver1.opendns.com will return nothing if not explicitly asking for IPv4.

Edit: tested with arch linux 2020

Signed-off-by: jenzo <>